### PR TITLE
Add caching for successful responses

### DIFF
--- a/lib/idempotent-request/request_manager.rb
+++ b/lib/idempotent-request/request_manager.rb
@@ -19,11 +19,8 @@ module IdempotentRequest
     def write(*data)
       status, headers, response = data
       response = response.body if response.respond_to?(:body)
-
-      return data unless status == 200
-
+      return data unless (200..226).include?(status)
       storage.write(key, payload(status, headers, response))
-
       data
     end
 

--- a/spec/idempotent-request/request_manager_spec.rb
+++ b/spec/idempotent-request/request_manager_spec.rb
@@ -81,14 +81,27 @@ RSpec.describe IdempotentRequest::RequestManager do
       })
     end
 
-    context 'when status is 200' do
-      let(:data) do
-        [200, {}, 'body']
+    describe 'when status 2xx' do
+      context 'when status is 200' do
+        let(:data) do
+          [200, {}, 'body']
+        end
+
+        it 'should be stored' do
+          request_storage.write(*data)
+          expect(memory_storage.read(request.key)).to eq(payload)
+        end
       end
 
-      it 'should be stored' do
-        request_storage.write(*data)
-        expect(memory_storage.read(request.key)).to eq(payload)
+      context 'when status is 226' do
+        let(:data) do
+          [226, {}, 'body']
+        end
+
+        it 'should be stored' do
+          request_storage.write(*data)
+          expect(memory_storage.read(request.key)).to eq(payload)
+        end
       end
     end
 
@@ -97,7 +110,7 @@ RSpec.describe IdempotentRequest::RequestManager do
         [404, {}, 'body']
       end
 
-      it 'should be stored' do
+      it 'should not be stored' do
         request_storage.write(*data)
         expect(memory_storage.read(request.key)).to be_nil
       end


### PR DESCRIPTION
It would be nice to cache not only `200` status responses but also other successful ones like `201 - created`, `202 - accepted`