### PR TITLE
Fix Ruby 2.7 Warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.2
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 deploy:
   skip_cleanup: true
   provider: rubygems

--- a/idempotent-request.gemspec
+++ b/idempotent-request.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack', '~> 2.0'
   spec.add_dependency 'oj', '~> 3.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'fakeredis', '~> 0.6'

--- a/lib/idempotent-request/request_manager.rb
+++ b/lib/idempotent-request/request_manager.rb
@@ -49,10 +49,10 @@ module IdempotentRequest
               response: Array(response))
     end
 
-    def run_callback(action, args)
+    def run_callback(action, **args)
       return unless @callback
 
-      @callback.new(request).send(action, args)
+      @callback.new(request).send(action, **args)
     end
 
     def key


### PR DESCRIPTION
Ruby 2.7 introduces warnings when using last argument as keyword parameters, as shown in this example:
```ruby
~/.rvm/gems/ruby-2.7.1/gems/idempotent-request-0.1.5/lib/idempotent-request/request_manager.rb:55: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
./lib/idempotent_request/callback.rb:11: warning: The called method `detected' is defined here
```

This PR fixes these warnings and removes bundler version requirement, allowing it to be build using any bundler version. Also added more ruby versions to build matrix.