### PR TITLE
Fix Ruby 2.7 warning

### DIFF
--- a/lib/idempotent-request/redis_storage.rb
+++ b/lib/idempotent-request/redis_storage.rb
@@ -27,14 +27,10 @@ module IdempotentRequest
     private
 
     def setnx_with_expiration(key, data)
-      redis.set(
-        key,
-        data,
-        {}.tap do |options|
-          options[:nx] = true
-          options[:ex] = expire_time.to_i if expire_time.to_i > 0
-        end
-      )
+      options = {nx: true}
+      options[:ex] = expire_time.to_i if expire_time.to_i > 0
+
+      redis.set(key, data, **options)
     end
 
     def lock_key(key)


### PR DESCRIPTION
Fix a kwargs-warning with Ruby 2.7:
```
gems/idempotent-request-0.1.6/lib/idempotent-request/redis_storage.rb:30: warning: Using the last
argument as keyword parameters is deprecated; maybe ** should be added to the call
```