### PR TITLE
Update to support rack 3

### DIFF
--- a/idempotent-request.gemspec
+++ b/idempotent-request.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rack', '~> 2.0'
+  spec.add_dependency 'rack', '~> 3.0'
   spec.add_dependency 'oj', '~> 3.0'
 
   spec.add_development_dependency 'bundler'

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module IdempotentRequest
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
Update to support rack 3
Currently the gem only supports applications with rack version smaller than 3.

This PR will support rack greater than 3